### PR TITLE
PV2-3875 Set it so that when the course type is short course it will …

### DIFF
--- a/src/SFA.DAS.Payments.ProviderPayments.Application.UnitTests/Mapping/ReportingAimFundingLineTypeMappingTest.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.Application.UnitTests/Mapping/ReportingAimFundingLineTypeMappingTest.cs
@@ -52,5 +52,22 @@ namespace SFA.DAS.Payments.ProviderPayments.Application.UnitTests.Mapping
 
             providerPayment.ReportingAimFundingLineType.Should().StartWith(expected);
         }
+
+        [Test]
+        [TestCase(ContractType.Act1, ApprenticeshipEmployerType.Levy, "16-18 Apprenticeship (From May 2017) Levy Contract", "16-18 Apprenticeship (From May 2017) Levy Contract")]
+        public void ShouldSetReportingAimFundingLineTypeToFundingLineTypeIfShortCourse(ContractType contractType, ApprenticeshipEmployerType employerType, string fundingLineType, string expected)
+        {
+            var fundingSourceEvent = new EmployerCoInvestedFundingSourcePaymentEvent
+            {
+                ContractType = contractType,
+                LearningAim = new LearningAim { FundingLineType = fundingLineType },
+                ApprenticeshipEmployerType = employerType,
+                CourseType = CourseType.ShortCourse
+            };
+
+            var providerPayment = mapper.Map<ProviderPaymentEventModel>(fundingSourceEvent);
+
+            providerPayment.ReportingAimFundingLineType.Should().Be(expected);
+        }
     }
 }

--- a/src/SFA.DAS.Payments.ProviderPayments.Application.UnitTests/Mapping/ReportingAimFundingLineTypeMappingTest.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.Application.UnitTests/Mapping/ReportingAimFundingLineTypeMappingTest.cs
@@ -54,7 +54,8 @@ namespace SFA.DAS.Payments.ProviderPayments.Application.UnitTests.Mapping
         }
 
         [Test]
-        [TestCase(ContractType.Act1, ApprenticeshipEmployerType.Levy, "16-18 Apprenticeship (From May 2017) Levy Contract", "16-18 Apprenticeship (From May 2017) Levy Contract")]
+        [TestCase(ContractType.Act1, ApprenticeshipEmployerType.Levy, "GSO Short Courses (Apprenticeship Units) Levy", "GSO Short Courses (Apprenticeship Units) Levy")]
+        [TestCase(ContractType.Act1, ApprenticeshipEmployerType.NonLevy, "GSO Short Courses (Apprenticeship Units) Non-Levy", "GSO Short Courses (Apprenticeship Units) Non-Levy")]
         public void ShouldSetReportingAimFundingLineTypeToFundingLineTypeIfShortCourse(ContractType contractType, ApprenticeshipEmployerType employerType, string fundingLineType, string expected)
         {
             var fundingSourceEvent = new EmployerCoInvestedFundingSourcePaymentEvent

--- a/src/SFA.DAS.Payments.ProviderPayments.Application/Mapping/ReportingAimFundingLineTypeValueResolver.cs
+++ b/src/SFA.DAS.Payments.ProviderPayments.Application/Mapping/ReportingAimFundingLineTypeValueResolver.cs
@@ -16,6 +16,11 @@ namespace SFA.DAS.Payments.ProviderPayments.Application.Mapping
             if (employerType != ApprenticeshipEmployerType.NonLevy && employerType != ApprenticeshipEmployerType.Levy)
                 return $"None (unknown employer type {employerType})";
 
+            if (source.CourseType == CourseType.ShortCourse)
+            {
+                return fundingLineType;
+            }
+
             if (contractType == ContractType.Act1)
             {
                 switch (fundingLineType)


### PR DESCRIPTION
…only return the fundingLineType. Also set up the corresponding tests for this - kept separate for readability